### PR TITLE
Refactor: Improve Code Readability

### DIFF
--- a/benches/bench_client_prepare_query.cpp
+++ b/benches/bench_client_prepare_query.cpp
@@ -8,6 +8,9 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_client_prepare_query(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+  using client_t = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
   constexpr size_t parsed_db_column_count = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
   constexpr size_t pub_matM_byte_len = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_column_count>::get_byte_len();
@@ -33,10 +36,10 @@ bench_client_prepare_query(benchmark::State& state)
   prng.read(seed_μ_span);
   prng.read(db_bytes_span);
 
-  auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+  auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
   M.to_le_bytes(pub_matM_bytes_span);
-  auto client = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ, pub_matM_bytes_span);
+  auto client = client_t::setup(seed_μ, pub_matM_bytes_span);
 
   size_t rand_db_row_index = [&]() {
     size_t buffer = 0;

--- a/benches/bench_client_process_response.cpp
+++ b/benches/bench_client_process_response.cpp
@@ -8,6 +8,9 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_client_process_response(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+  using client_t = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
   constexpr size_t parsed_db_column_count = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
   constexpr size_t pub_matM_byte_len = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_column_count>::get_byte_len();
@@ -33,10 +36,10 @@ bench_client_process_response(benchmark::State& state)
   prng.read(seed_μ_span);
   prng.read(db_bytes_span);
 
-  auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+  auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
   M.to_le_bytes(pub_matM_bytes_span);
-  auto client = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ, pub_matM_bytes_span);
+  auto client = client_t::setup(seed_μ, pub_matM_bytes_span);
 
   size_t rand_db_row_index = [&]() {
     size_t buffer = 0;

--- a/benches/bench_client_query.cpp
+++ b/benches/bench_client_query.cpp
@@ -8,6 +8,9 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_client_query(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+  using client_t = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
   constexpr size_t parsed_db_column_count = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
   constexpr size_t pub_matM_byte_len = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_column_count>::get_byte_len();
@@ -33,10 +36,10 @@ bench_client_query(benchmark::State& state)
   prng.read(seed_μ_span);
   prng.read(db_bytes_span);
 
-  auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+  auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
   M.to_le_bytes(pub_matM_bytes_span);
-  auto client = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ, pub_matM_bytes_span);
+  auto client = client_t::setup(seed_μ, pub_matM_bytes_span);
 
   size_t rand_db_row_index = [&]() {
     size_t buffer = 0;

--- a/benches/bench_client_setup.cpp
+++ b/benches/bench_client_setup.cpp
@@ -8,6 +8,9 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_client_setup(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+  using client_t = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
   constexpr size_t parsed_db_column_count = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
   constexpr size_t pub_matM_byte_len = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_column_count>::get_byte_len();
@@ -25,12 +28,12 @@ bench_client_setup(benchmark::State& state)
   prng.read(seed_μ_span);
   prng.read(db_bytes_span);
 
-  auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+  auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
   M.to_le_bytes(pub_matM_bytes_span);
 
   for (auto _ : state) {
-    auto client = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ, pub_matM_bytes_span);
+    auto client = client_t::setup(seed_μ, pub_matM_bytes_span);
 
     benchmark::DoNotOptimize(client);
     benchmark::DoNotOptimize(seed_μ);

--- a/benches/bench_server_respond.cpp
+++ b/benches/bench_server_respond.cpp
@@ -8,6 +8,9 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_server_respond(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+  using client_t = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
   constexpr size_t parsed_db_column_count = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
   constexpr size_t pub_matM_byte_len = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_column_count>::get_byte_len();
@@ -31,10 +34,10 @@ bench_server_respond(benchmark::State& state)
   prng.read(seed_μ_span);
   prng.read(db_bytes_span);
 
-  auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+  auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
   M.to_le_bytes(pub_matM_bytes_span);
-  auto client = frodoPIR_client::client_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ, pub_matM_bytes_span);
+  auto client = client_t::setup(seed_μ, pub_matM_bytes_span);
 
   const size_t rand_db_row_index = [&]() {
     size_t buffer = 0;

--- a/benches/bench_server_setup.cpp
+++ b/benches/bench_server_setup.cpp
@@ -6,6 +6,8 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 static void
 bench_server_setup(benchmark::State& state)
 {
+  using server_t = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>;
+
   constexpr size_t db_byte_len = db_entry_count * db_entry_byte_len;
 
   std::array<uint8_t, λ / std::numeric_limits<uint8_t>::digits> seed_μ{};
@@ -20,7 +22,7 @@ bench_server_setup(benchmark::State& state)
   prng.read(db_bytes_span);
 
   for (auto _ : state) {
-    auto [server, M] = frodoPIR_server::server_t<λ, db_entry_count, db_entry_byte_len, mat_element_bitlen, lwe_dimension>::setup(seed_μ_span, db_bytes_span);
+    auto [server, M] = server_t::setup(seed_μ_span, db_bytes_span);
 
     benchmark::DoNotOptimize(seed_μ_span);
     benchmark::DoNotOptimize(db_bytes_span);

--- a/include/frodoPIR/internals/matrix/matrix.hpp
+++ b/include/frodoPIR/internals/matrix/matrix.hpp
@@ -318,7 +318,33 @@ public:
     requires(std::endian::native == std::endian::little)
   {
     auto elements_ptr = reinterpret_cast<const uint8_t*>(this->elements.data());
-    memcpy(bytes.data(), elements_ptr, bytes.size());
+    auto bytes_ptr = reinterpret_cast<uint8_t*>(bytes.data());
+
+    constexpr size_t min_num_threads = 1;
+    const size_t hw_hinted_max_num_threads = std::thread::hardware_concurrency();
+    const size_t spawnable_num_threads = std::max(min_num_threads, hw_hinted_max_num_threads);
+
+    constexpr size_t total_num_bytes = bytes.size();
+    const size_t num_bytes_per_thread = total_num_bytes / spawnable_num_threads;
+    const size_t num_bytes_distributed = num_bytes_per_thread * spawnable_num_threads;
+    const size_t remaining_num_bytes = total_num_bytes - num_bytes_distributed;
+
+    std::vector<std::thread> threads;
+    threads.reserve(spawnable_num_threads);
+
+    for (size_t t_idx = 0; t_idx < spawnable_num_threads; t_idx++) {
+      const size_t byte_idx_begin = t_idx * num_bytes_per_thread;
+
+      auto thread = std::thread([=, &elements_ptr, &bytes_ptr]() { memcpy(bytes_ptr + byte_idx_begin, elements_ptr + byte_idx_begin, num_bytes_per_thread); });
+      threads.push_back(std::move(thread));
+    }
+
+    if (remaining_num_bytes > 0) {
+      const size_t final_thread_byte_idx_begin = num_bytes_distributed;
+      memcpy(bytes_ptr + final_thread_byte_idx_begin, elements_ptr + final_thread_byte_idx_begin, remaining_num_bytes);
+    }
+
+    std::ranges::for_each(threads, [](auto& handle) { handle.join(); });
   }
 
   // Given a byte array of length `rows * cols * 4`, this routine can be used for deserializing it as a matrix of dimension

--- a/include/frodoPIR/server.hpp
+++ b/include/frodoPIR/server.hpp
@@ -17,8 +17,20 @@ template<size_t λ, size_t db_entry_count, size_t db_entry_byte_len, size_t mat_
 struct server_t
 {
 public:
+  // Compile-time computable values.
+  static constexpr auto parsed_db_num_cols = frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen);
+  static constexpr auto orig_db_byte_len = db_entry_count * db_entry_byte_len;
+  static constexpr auto query_byte_len = db_entry_count * sizeof(frodoPIR_matrix::zq_t);
+  static constexpr auto response_byte_len = parsed_db_num_cols * sizeof(frodoPIR_matrix::zq_t);
+
+  // Type aliases.
+  using pub_mat_A_t = frodoPIR_matrix::matrix_t<lwe_dimension, db_entry_count>;
+  using pub_mat_M_t = frodoPIR_matrix::matrix_t<lwe_dimension, parsed_db_num_cols>;
+  using parsed_db_t = frodoPIR_matrix::matrix_t<db_entry_count, parsed_db_num_cols>;
+  using query_t = frodoPIR_vector::row_vector_t<db_entry_count>;
+
   // Constructor(s)
-  explicit constexpr server_t(frodoPIR_matrix::matrix_t<db_entry_count, frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen)> db)
+  explicit constexpr server_t(auto db)
     : D(std::move(db))
   {
   }
@@ -32,11 +44,10 @@ public:
   // each entry is of `db_entry_byte_len` -bytes, this routine can be used for setting up FrodoPIR server,
   // returning initialized server (ready to respond to client queries) handle and public matrix M, which will
   // be used by clients for preprocessing queries.
-  static forceinline constexpr std::
-    pair<server_t, frodoPIR_matrix::matrix_t<lwe_dimension, frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen)>>
-    setup(std::span<const uint8_t, λ / std::numeric_limits<uint8_t>::digits> seed_μ, std::span<const uint8_t, db_entry_count * db_entry_byte_len> db_bytes)
+  static forceinline constexpr std::pair<server_t, pub_mat_M_t> setup(std::span<const uint8_t, λ / std::numeric_limits<uint8_t>::digits> seed_μ,
+                                                                      std::span<const uint8_t, orig_db_byte_len> db_bytes)
   {
-    const auto A = frodoPIR_matrix::matrix_t<lwe_dimension, db_entry_count>::template generate<λ>(seed_μ);
+    const auto A = pub_mat_A_t::template generate<λ>(seed_μ);
     const auto D = frodoPIR_serialization::parse_db_bytes<db_entry_count, db_entry_byte_len, mat_element_bitlen>(db_bytes);
     const auto M = A * D;
 
@@ -44,18 +55,16 @@ public:
   }
 
   // Given byte serialized client query, this routine can be used for responding back to it, producing byte serialized server response.
-  constexpr void respond(
-    std::span<const uint8_t, db_entry_count * sizeof(frodoPIR_matrix::zq_t)> query_bytes,
-    std::span<uint8_t, frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen) * sizeof(frodoPIR_matrix::zq_t)> response_bytes) const
+  constexpr void respond(std::span<const uint8_t, query_byte_len> query_bytes, std::span<uint8_t, response_byte_len> response_bytes) const
   {
-    const auto b_tilda = frodoPIR_vector::row_vector_t<db_entry_count>::from_le_bytes(query_bytes);
+    const auto b_tilda = query_t::from_le_bytes(query_bytes);
     const auto c_tilda = b_tilda * this->D;
 
     c_tilda.to_le_bytes(response_bytes);
   }
 
 private:
-  frodoPIR_matrix::matrix_t<db_entry_count, frodoPIR_matrix::get_required_num_columns(db_entry_byte_len, mat_element_bitlen)> D{};
+  parsed_db_t D{};
 };
 
 }


### PR DESCRIPTION
Use `using` keyword to make repetitive names shorter - making code easier to parse through.
